### PR TITLE
Add public fields with item resources for dialogue

### DIFF
--- a/Entities/Items/inventory_system.gd
+++ b/Entities/Items/inventory_system.gd
@@ -7,6 +7,24 @@ signal item_removed(item: Item)
 
 var items = {} #Idiomatic set
 
+# Named item fields so that items can be referenced from dialogues
+var BOOZE_CLOSED: Item = preload("res://Entities/Items/Booze_Closed.tres")
+var BOOZE_OPEN: Item = preload("res://Entities/Items/Booze_Open.tres")
+var BOOZE_SCREWED: Item = preload("res://Entities/Items/Booze_ScrewInCork.tres")
+var CANDLES: Item = preload("res://Entities/Items/Candles.tres")
+var FLASHLIGHT: Item = preload("res://Entities/Items/Flashlight.tres")
+var HAMMER: Item = preload("res://Entities/Items/Hammer.tres")
+var KAZOO: Item = preload("res://Entities/Items/Kazoo.tres")
+var KNIFE: Item = preload("res://Entities/Items/Knife.tres")
+var LIGHTER: Item = preload("res://Entities/Items/Lighter.tres")
+var CANDLES_LIT: Item = preload("res://Entities/Items/LitCandles.tres")
+var PORKRINDS: Item = preload("res://Entities/Items/PorkRinds.tres")
+var RITUAL_TAPE: Item = preload("res://Entities/Items/RitualTape.tres")
+var ROAD_FLARE: Item = preload("res://Entities/Items/RoadFlare.tres")
+var SAFE_NOTE: Item = preload("res://Entities/Items/SafeNote.tres")
+var SAFE_NOTE_TRANSLATED: Item = preload("res://Entities/Items/SafeNote_Translated.tres")
+var SCREW: Item = preload("res://Entities/Items/Screw.tres")
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	_load_recipes("res://Entities/Items/Recipes/")

--- a/project.godot
+++ b/project.godot
@@ -48,4 +48,4 @@ dialogue_bubble="group to make this easier to find"
 
 [internationalization]
 
-locale/translations_pot_files=PackedStringArray("res://Utilities/Debug/example_dialogue_test.dialogue", "res://Entities/Dialogues/flashlight.dialogue", "res://Entities/Dialogues/candles.dialogue", "res://Entities/Dialogues/items.dialogue", "res://Entities/Dialogues/rooms.dialogue", "res://Entities/Dialogues/test_dialogue.dialogue")
+locale/translations_pot_files=PackedStringArray("res://Utilities/Debug/example_dialogue_test.dialogue", "res://Entities/Dialogues/flashlight.dialogue", "res://Entities/Dialogues/candles.dialogue", "res://Entities/Dialogues/items.dialogue", "res://Entities/Dialogues/rooms.dialogue")

--- a/project.godot
+++ b/project.godot
@@ -26,7 +26,7 @@ SceneManager="*res://Utilities/World/SceneManager/SceneManager.gd"
 [dialogue_manager]
 
 general/balloon_path="res://Utilities/Debug/balloon.tscn"
-general/states=["PersistenceSystem"]
+general/states=["PersistenceSystem", "InventorySystem"]
 
 [display]
 
@@ -48,4 +48,4 @@ dialogue_bubble="group to make this easier to find"
 
 [internationalization]
 
-locale/translations_pot_files=PackedStringArray("res://Utilities/Debug/example_dialogue_test.dialogue", "res://Entities/Dialogues/flashlight.dialogue", "res://Entities/Dialogues/candles.dialogue", "res://Entities/Dialogues/items.dialogue", "res://Entities/Dialogues/rooms.dialogue")
+locale/translations_pot_files=PackedStringArray("res://Utilities/Debug/example_dialogue_test.dialogue", "res://Entities/Dialogues/flashlight.dialogue", "res://Entities/Dialogues/candles.dialogue", "res://Entities/Dialogues/items.dialogue", "res://Entities/Dialogues/rooms.dialogue", "res://Entities/Dialogues/test_dialogue.dialogue")


### PR DESCRIPTION
Since it doesn't look like dialogue manager has a way to work with resources directly (?), but does seem to recognize them, I made a thing!

With fields for each item, you can use them like constants when checking for, taking away, or giving items. Ex:
if has_item(SAFE_NOTE)
	Liz: I can translate that!
	do remove_item(SAFE_NOTE)
	do add_item(SAFE_NOTE_TRANSLATED)
=> END