### PR TITLE
Add NPC click and drag'n'drop dialogue

### DIFF
--- a/Entities/Dialogues/mark.dialogue
+++ b/Entities/Dialogues/mark.dialogue
@@ -6,6 +6,8 @@ Mark: "I'm freaking out man... I'M FREAKING OUT!"
 # Add an interaction here for when you are holding the candles
 Mark: "Hey man are those candles? You need a light?"
 - YES
+	Mark: "Here, take this."
+	do add_item(LIGHTER)
 - Of Course!
 - YESTERDAY!!
 => END

--- a/Entities/Rooms/foyer.tscn
+++ b/Entities/Rooms/foyer.tscn
@@ -1,9 +1,14 @@
-[gd_scene load_steps=5 format=3 uid="uid://b2kllhl8485ma"]
+[gd_scene load_steps=10 format=3 uid="uid://b2kllhl8485ma"]
 
 [ext_resource type="Script" path="res://Entities/Rooms/rooms.gd" id="1_8f0w4"]
 [ext_resource type="PackedScene" uid="uid://1lo83hf88q04" path="res://Entities/UI/Pickup/pickup.tscn" id="1_30hve"]
 [ext_resource type="Texture2D" uid="uid://gr1cxq8rc5fl" path="res://Scenes/main_room.png" id="1_rv80l"]
 [ext_resource type="Resource" uid="uid://cea6fwhue3qs5" path="res://Entities/Dialogues/items.dialogue" id="3_q5dbv"]
+[ext_resource type="Script" path="res://Entities/npc.gd" id="5_cbahj"]
+[ext_resource type="Resource" uid="uid://cga7mmef6xi77" path="res://Entities/Dialogues/lisa.dialogue" id="6_t5qpw"]
+[ext_resource type="Resource" uid="uid://n0mu2mq6o75i" path="res://Entities/Items/Candles.tres" id="7_do1n4"]
+[ext_resource type="Resource" uid="uid://bvqfce8qh2w7f" path="res://Entities/Items/SafeNote.tres" id="7_npgyr"]
+[ext_resource type="Resource" uid="uid://dt44wpd33umol" path="res://Entities/Dialogues/mark.dialogue" id="8_j1c3a"]
 
 [node name="Foyer" type="Control"]
 layout_mode = 3
@@ -15,16 +20,43 @@ grow_vertical = 2
 script = ExtResource("1_8f0w4")
 dialogue_start = "foyer"
 
-[node name="TextureRect" type="TextureRect" parent="."]
+[node name="Background" type="TextureRect" parent="."]
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
 texture = ExtResource("1_rv80l")
 
-[node name="Pickup" parent="TextureRect" instance=ExtResource("1_30hve")]
+[node name="Candles" parent="Background" instance=ExtResource("1_30hve")]
 layout_mode = 1
 offset_left = -1.0
 offset_right = -833.0
 offset_bottom = -392.0
 dialogue_resource = ExtResource("3_q5dbv")
 dialogue_start = "candles"
+
+[node name="Mark" type="Control" parent="Background"]
+anchors_preset = 0
+offset_left = 429.0
+offset_top = 113.0
+offset_right = 560.0
+offset_bottom = 462.0
+script = ExtResource("5_cbahj")
+dialogue_resource = ExtResource("8_j1c3a")
+item_titles = {
+ExtResource("7_do1n4"): "candles"
+}
+
+[node name="Lisa" type="Control" parent="Background"]
+anchors_preset = 0
+offset_left = 282.0
+offset_top = 140.0
+offset_right = 379.0
+offset_bottom = 462.0
+script = ExtResource("5_cbahj")
+dialogue_resource = ExtResource("6_t5qpw")
+item_titles = {
+ExtResource("7_npgyr"): "german_note"
+}
+
+[connection signal="gui_input" from="Background/Mark" to="Background/Mark" method="_on_gui_input"]
+[connection signal="gui_input" from="Background/Lisa" to="Background/Lisa" method="_on_gui_input"]

--- a/Entities/npc.gd
+++ b/Entities/npc.gd
@@ -1,0 +1,23 @@
+extends Control
+class_name NPC
+
+@export var dialogue_resource: DialogueResource
+@export var item_titles: Dictionary
+@export var dialogue_start: String = "start"
+@export var unhandled_item_title: String = "unhandled_item"
+@onready var dialogue_bubble = get_tree().get_first_node_in_group("dialogue_bubble")
+
+func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
+	return data.Item is Item
+
+func _drop_data(at_position: Vector2, data: Variant):
+	var item = data.Item
+	if item_titles.has(item):
+		dialogue_bubble.start(dialogue_resource, item_titles[item])
+		
+
+func _on_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		if event.pressed: # need to put a timer or something in here to prevent single click triggering
+			if dialogue_resource != null:
+				dialogue_bubble.start(dialogue_resource, dialogue_start)


### PR DESCRIPTION
- Can now use a map on the NPC to match an item to a specific dialogue title (or a configurable unhandled title if not matched)
- The Dictionary UI is a little bit of a pain- you have to select the type for the key and the value since GDScript Dictionaries are Variant/Variant. Just pick 'Object' for the key so you can drop an item on it, pick 'String' for the value, and type in the title you want. 